### PR TITLE
feat(storage): refactor review result storage for reliability and sca…

### DIFF
--- a/ReviewSharpApp/Program.cs
+++ b/ReviewSharpApp/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddScoped<ICodeReviewSemanticService, UnusedUsingService>();
 builder.Services.AddScoped<ICodeReviewService, FileNameMatchClassService>();
 builder.Services.AddScoped<ICodeReviewService, NestedBlockDepthService>();
 builder.Services.AddScoped<IFileProcessingService, FileProcessingService>();
+builder.Services.AddSingleton<ReviewSharp.Services.ReviewResultStorageService>();
 
 
 var app = builder.Build();
@@ -51,7 +52,7 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
     app.UseHttpsRedirection();
 }
-
+app.UseStaticFiles();
 app.UseRouting();
 
 app.UseSession();

--- a/ReviewSharpApp/Properties/PublishProfiles/site35341-WebDeploy.pubxml
+++ b/ReviewSharpApp/Properties/PublishProfiles/site35341-WebDeploy.pubxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project>
+  <PropertyGroup>
+    <WebPublishMethod>MSDeploy</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish>http://reviewharp.runasp.net/</SiteUrlToLaunchAfterPublish>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <ProjectGuid>5abeca1f-fcab-40e9-9cc7-02fdc3521f2b</ProjectGuid>
+    <MSDeployServiceURL>site35341.siteasp.net</MSDeployServiceURL>
+    <DeployIisAppPath>site35341</DeployIisAppPath>
+    <RemoteSitePhysicalPath />
+    <SkipExtraFilesOnServer>true</SkipExtraFilesOnServer>
+    <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
+    <EnableMSDeployBackup>true</EnableMSDeployBackup>
+    <EnableMsDeployAppOffline>true</EnableMsDeployAppOffline>
+    <UserName>site35341</UserName>
+    <_SavePWD>true</_SavePWD>
+  </PropertyGroup>
+</Project>

--- a/ReviewSharpApp/Services/CodeReviewOrchestratorService.cs
+++ b/ReviewSharpApp/Services/CodeReviewOrchestratorService.cs
@@ -90,7 +90,9 @@ namespace ReviewSharp.Services
             var fileMap = new Dictionary<string, SyntaxTree>();
             foreach (var filePath in csFiles)
             {
-                var fileName = Path.GetRelativePath(tempExtractDir, filePath);
+                var fileName = Path.GetRelativePath(tempExtractDir, filePath)
+                    .Replace("\\", "/")
+                    .ToLowerInvariant();
                 if (IsNonReviewable(filePath, fileName)) continue;
                 try
                 {

--- a/ReviewSharpApp/Services/FileProcessingService.cs
+++ b/ReviewSharpApp/Services/FileProcessingService.cs
@@ -33,9 +33,11 @@ namespace ReviewSharp.Services
             var csFiles = Directory.GetFiles(tempExtractDir, "*.cs", SearchOption.AllDirectories);
             foreach (var filePath in csFiles)
             {
-                var fileName = Path.GetRelativePath(tempExtractDir, filePath);
-                var code = await File.ReadAllTextAsync(filePath);
-                fileCodes[fileName] = code;
+                var fileName = Path.GetRelativePath(tempExtractDir, filePath)
+                    .Replace("\\", "/")
+                    .ToLowerInvariant();
+                // Ensure normalization is consistent
+                fileCodes[fileName] = await File.ReadAllTextAsync(filePath);
             }
             try { File.Delete(tempZipPath); Directory.Delete(tempExtractDir, true); } catch { }
             return fileCodes;

--- a/ReviewSharpApp/Services/ReviewResultStorageService.cs
+++ b/ReviewSharpApp/Services/ReviewResultStorageService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace ReviewSharp.Services
+{
+    public class ReviewResultStorageService
+    {
+        private static string TempDir => Path.Combine(Path.GetTempPath(), "ReviewSharpResults");
+
+        public ReviewResultStorageService()
+        {
+            if (!Directory.Exists(TempDir))
+                Directory.CreateDirectory(TempDir);
+        }
+
+        public async Task<string> SaveResultsAsync(Dictionary<string, List<ReviewSharp.Models.CodeReviewResult>> resultsByFile, Dictionary<string, string> fileCodes)
+        {
+            var key = Guid.NewGuid().ToString("N");
+            var filePath = Path.Combine(TempDir, $"review_{key}.json");
+            var payload = new ReviewResultPayload { ResultsByFile = resultsByFile, FileCodes = fileCodes };
+            var json = JsonSerializer.Serialize(payload);
+            await File.WriteAllTextAsync(filePath, json);
+            return key;
+        }
+
+        public async Task<ReviewResultPayload?> LoadResultsAsync(string key)
+        {
+            var filePath = Path.Combine(TempDir, $"review_{key}.json");
+            if (!File.Exists(filePath)) return null;
+            var json = await File.ReadAllTextAsync(filePath);
+            return JsonSerializer.Deserialize<ReviewResultPayload>(json);
+        }
+
+        public class ReviewResultPayload
+        {
+            public Dictionary<string, List<ReviewSharp.Models.CodeReviewResult>> ResultsByFile { get; set; } = new();
+            public Dictionary<string, string> FileCodes { get; set; } = new();
+        }
+    }
+}

--- a/ReviewSharpApp/Views/CodeReview/ResultFolder.cshtml
+++ b/ReviewSharpApp/Views/CodeReview/ResultFolder.cshtml
@@ -55,20 +55,9 @@ function showCodePanel(fileKey) {
 }
 </script>
 
-@inject Microsoft.AspNetCore.Http.IHttpContextAccessor HttpContextAccessor
 @{
-    Dictionary<string, List<ReviewSharp.Models.CodeReviewResult>>? resultsByFile = null;
-    Dictionary<string, string>? fileCodes = null;
-    var resultsByFileJson = HttpContextAccessor?.HttpContext?.Session?.GetString("ResultsByFile");
-    var fileCodesJson = HttpContextAccessor?.HttpContext?.Session?.GetString("FileCodes");
-    if (!string.IsNullOrEmpty(resultsByFileJson))
-    {
-        resultsByFile = JsonSerializer.Deserialize<Dictionary<string, List<ReviewSharp.Models.CodeReviewResult>>>(resultsByFileJson) ?? new();
-    }
-    if (!string.IsNullOrEmpty(fileCodesJson))
-    {
-        fileCodes = JsonSerializer.Deserialize<Dictionary<string, string>>(fileCodesJson) ?? new();
-    }
+    var resultsByFile = ViewBag.ResultsByFile as Dictionary<string, List<ReviewSharp.Models.CodeReviewResult>>;
+    var fileCodes = ViewBag.FileCodes as Dictionary<string, string>;
 }
 <div class="container-fluid py-4" style="max-width: 1400px; margin:auto;">
     @if (TempData["Error"] != null)
@@ -96,7 +85,7 @@ function showCodePanel(fileKey) {
                 <div class="card-header bg-dark text-white rounded-top-4 d-flex justify-content-between align-items-center">
                     <strong>@fileKey</strong>
                     <span class="badge bg-info px-3 py-2">@fileResults.Count Total</span>
-                    <a class="btn btn-outline-primary btn-sm ms-3" href="@Url.Action("ShowFileResult", "CodeReview", new { fileName = fileKey })" target="_blank">Show Code</a>
+                    <a class="btn btn-outline-primary btn-sm ms-3" href="@Url.Action("ShowFileResult", "CodeReview", new { fileName = System.Net.WebUtility.UrlEncode(fileKey), key = ViewContext.RouteData.Values["key"] ?? (Context.Request.Query["key"].ToString() ?? (ViewBag.Key ?? "")) })" target="_blank">Show Code</a>
                 </div>
                 <div class="card-body p-3">
                     <div id="code-panel-@panelKey" style="display:none;">


### PR DESCRIPTION
…lability

- implement ReviewResultStorageService to store review results and code in temp files, keyed by GUID
- refactor CodeReviewController to use temp file storage and pass only the key in session and URLs
- normalize file keys for consistent lookup across services to prevent mismatches
- update ResultFolder.cshtml to use ViewBag for results and code, not session, ensuring correct display after upload
- ensure Show Code button passes the review result key for robust navigation, supporting multi-tab and session timeout scenarios

This enables reliable multi-file review, robust navigation, and avoids session size/time issues across all hosts.